### PR TITLE
Full type hinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # digital-dostoevsky-tagger
 
-![Python Version](https://img.shields.io/badge/python-3.8|3.9|3.10-blue?logo=python&logoColor=white)
+![Python Version](https://img.shields.io/badge/python-3.10-blue?logo=python&logoColor=white)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 The modules in this repository can be used to parse raw text files from the corpus of the Digital Dostoevsky Project and apply basic TEI markup to them.
@@ -26,7 +26,7 @@ The markup applied is of three kinds:
 
 ## Usage
 
-The modules and CLI require Python >= 3.8.  The only non-stdlib dependencies are `lxml` and `regex` -- install them using `pip install -r requirements.txt` or similar.
+The modules and CLI require Python >= 3.10.  The only non-stdlib dependencies are `lxml` and `regex` -- install them using `pip install -r requirements.txt` or similar.
 
 ```sh
 usage: parse_file.py [-h] [-v] [-q] [-o OUTPUT] [--rng-schema RNG_SCHEMA] [--person-names-list PERSON_NAMES_LIST] [--place-names-list PLACE_NAMES_LIST] input_text

--- a/parse_file.py
+++ b/parse_file.py
@@ -28,7 +28,7 @@ XML_PROCESSING_INSTRUCTIONS = [
 ]
 
 
-def create_tei_structure(text):
+def create_tei_structure(text: str) -> str:
     """Create TEI structure for the given text."""
 
     return f"""\
@@ -57,7 +57,7 @@ def create_tei_structure(text):
 """
 
 
-def format_tree(elem, indent="  ", level=0):
+def format_tree(elem: etree._Element, indent: str = "  ", level: int = 0) -> None:
     """Pretty-prints and indents a tree beautifully."""
     i = "\n%s" % (level * indent)
     if elem.tag == "{http://www.tei-c.org/ns/1.0}p":
@@ -77,7 +77,7 @@ def format_tree(elem, indent="  ", level=0):
             elem.tail = i
 
 
-def main():
+def main() -> None:
     """Command-line entry-point."""
 
     parser = argparse.ArgumentParser(description="Description: {}".format(__doc__))
@@ -140,6 +140,7 @@ def main():
     sections = parse_sections(text)
     text = markup_sections(sections)
 
+    output_path = None
     if args.output:
         output_path = Path(args.output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -149,7 +150,7 @@ def main():
 
     logging.info("Writing processed text to: %s", args.output or "stdout")
 
-    with output_path.open("wt", encoding="utf8") if args.output else sys.stdout as _fh:
+    with output_path.open("wt", encoding="utf8") if output_path else sys.stdout as _fh:
         _fh.write("\n".join(XML_PROCESSING_INSTRUCTIONS) + "\n")
         _fh.write(etree.tostring(doc, pretty_print=True, encoding="unicode"))
 

--- a/parse_sections.py
+++ b/parse_sections.py
@@ -1,14 +1,31 @@
 import logging
 import re
+from typing_extensions import NotRequired, TypedDict
+
+Section = TypedDict(
+    "Section",
+    {
+        "numeral": str | None,
+        "lines": list[str],
+        "title": NotRequired[str],
+        "subtitle": NotRequired[str],
+        "prev_titles": NotRequired[dict[str, str]],
+        "section_title": NotRequired[str],
+    },
+)
+
+SectionAttribs = TypedDict("SectionAttribs", {"type": str, "n": int})
 
 
-def is_roman_numeral(text):
+def is_roman_numeral(text: str) -> bool:
     if not text:
         return False
     return all([c in "IVX" for c in text])
 
 
-def roman_to_arabic(s: str) -> int:
+def roman_to_arabic(s: str | None) -> int:
+    if s is None:
+        return -1
     s = s.upper()
     roman = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
     num = 0
@@ -23,16 +40,16 @@ def roman_to_arabic(s: str) -> int:
     return num
 
 
-def parse_sections(text):
+def parse_sections(text: str) -> list[Section]:
 
     titles = ["div1", "div2", "chapter_title"]
     first_section = True
 
-    sections = []
+    sections: list[Section] = []
     buffer = [""]  # ensure an empty line at the top of the document
 
     section_numeral = None
-    for i, line in enumerate(text.splitlines()):
+    for line in text.splitlines():
         line = line.strip(" \t\n")
         if is_roman_numeral(line):
             sections.append({"numeral": section_numeral, "lines": buffer})
@@ -41,14 +58,15 @@ def parse_sections(text):
         else:
             buffer.append(line)
 
+    section: Section
     for i, section in enumerate(sections):
         if section["numeral"] is not None:
 
-            prev_section = sections[i - 1]
+            prev_section: Section = sections[i - 1]
             integer = roman_to_arabic(section["numeral"])
 
             if integer == 1:
-                prev_titles = []
+                prev_titles: list[str] = []
 
                 # iterate lines from the previous section
                 #  - bottom up, two at a time
@@ -120,16 +138,17 @@ def parse_sections(text):
     return sections
 
 
-def markup_sections(sections):
+def markup_sections(sections: list[Section]) -> str:
 
     first_section = True
+    has_chapters = False
     buffer = ["<body>"]
-    section_attribs = {
+    section_attribs: dict[str, SectionAttribs] = {
         "div1": {"type": "part", "n": 0},
         "div2": {"type": "chapter", "n": 0},
     }
 
-    def get_section_markup(section_type, heading_text):
+    def get_section_markup(section_type: str, heading_text: str) -> str:
         section_attribs[section_type]["n"] += 1
         attribs = " ".join(
             f'{k}="{v}"' for k, v in section_attribs[section_type].items()
@@ -199,7 +218,7 @@ if __name__ == "__main__":
     # The following code is used for testing and development purposes only.
     import sys
 
-    with open(sys.argv[1], "rt") as _fh:
+    with open(sys.argv[1], "rt", encoding="utf8") as _fh:
         text = _fh.read()
 
     sections = parse_sections(text)

--- a/proper_names.py
+++ b/proper_names.py
@@ -1,7 +1,7 @@
 import re
 
 
-def markup_proper_names(text, names, tag):
+def markup_proper_names(text: str, names: list[str], tag: str) -> str:
 
     re_proper_names = re.compile(
         rf"\b(?:{'|'.join(sorted(names, key=len, reverse=True))})\b"


### PR DESCRIPTION
This branch introduces full type hinting.  However, to properly support the needed types required python >= 3.10.  Since the code is otherwise compatible with python >= 3.8 (and could very easily be made compatible with python 3.7 and probably 3.6), I'm just going to leave the here unmerged at this time.